### PR TITLE
fix: Update download script to create data directory if it doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "npm run build && time node dist/index.js",
     "dev": "time tsx src/index.ts",
-    "download": "[ ! -f data/data.csv.gz ] && curl -L -o data/data.csv.gz 'https://drive.usercontent.google.com/download?id=1A_OCjRyHnCCMZbgT0Z5KN70pJXMA8TYD&export=download&authuser=0&confirm=t&uuid=6a3b0b9e-5988-4fd1-9af6-297c2365ea02&at=11ynXQrkYTZMQE70G7EqfypcaWp3f9eWV'",
+    "download": "mkdir -p data && [ ! -f data/data.csv.gz ] && curl -L -o data/data.csv.gz 'https://drive.usercontent.google.com/download?id=1A_OCjRyHnCCMZbgT0Z5KN70pJXMA8TYD&export=download&authuser=0&confirm=t&uuid=6a3b0b9e-5988-4fd1-9af6-297c2365ea02&at=11ynXQrkYTZMQE70G7EqfypcaWp3f9eWV'",
     "small-file": "npm run download ; gzcat data/data.csv.gz | head -n 10000000 > data/data.csv",
     "big-file": "npm run download ; gzcat data/data.csv.gz | head -n 100000000 > data/data.csv",
     "real-file": "npm run download ; gzcat data/data.csv.gz > data/data.csv"


### PR DESCRIPTION
If data directory is not there download will fail as well as the others depending on it.